### PR TITLE
Stop reddit from sending HTML entities in JSON

### DIFF
--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -140,7 +140,8 @@ func (o *operator) IsThereThing(id string) (bool, error) {
 				Host:   oauth2Host,
 				Path:   path,
 				RawQuery: url.Values{
-					"id": []string{id},
+					"id":       []string{id},
+					"raw_json": []string{"1"},
 				}.Encode(),
 			},
 			Host: oauth2Host,
@@ -182,9 +183,10 @@ func (o *operator) Thread(permalink string) (*redditproto.Link, error) {
 			ProtoMinor: 1,
 			Close:      true,
 			URL: &url.URL{
-				Scheme: "https",
-				Host:   oauth2Host,
-				Path:   fmt.Sprintf("%s.json", permalink),
+				Scheme:   "https",
+				Host:     oauth2Host,
+				Path:     fmt.Sprintf("%s.json", permalink),
+				RawQuery: "raw_json=1",
 			},
 			Host: oauth2Host,
 		},
@@ -206,9 +208,10 @@ func (o *operator) Inbox() ([]*redditproto.Message, error) {
 			ProtoMinor: 1,
 			Close:      true,
 			URL: &url.URL{
-				Scheme: "https",
-				Host:   oauth2Host,
-				Path:   "/message/unread",
+				Scheme:   "https",
+				Host:     oauth2Host,
+				Path:     "/message/unread",
+				RawQuery: "raw_json=1",
 			},
 			Host: oauth2Host,
 		},
@@ -349,9 +352,10 @@ func (o *operator) exec(r http.Request) ([]byte, error) {
 // endpoint.
 func listingParams(limit uint, after, before string) string {
 	return url.Values{
-		"limit":  []string{strconv.Itoa(int(limit))},
-		"before": []string{before},
-		"after":  []string{after},
+		"limit":    []string{strconv.Itoa(int(limit))},
+		"before":   []string{before},
+		"after":    []string{after},
+		"raw_json": []string{"1"},
 	}.Encode()
 }
 


### PR DESCRIPTION
In responses to API calls, reddit apparently converts a few characters
to HTML entites. The API documentation states:

https://www.reddit.com/dev/api#response_body_encoding
> For legacy reasons, all JSON response bodies currently have <, >, and
> & replaced with &lt;, &gt;, and &amp;, respectively. If you wish to
> opt out of this behaviour, add a raw_json=1 parameter to your request.

Such behavior offers no benefit to users of graw, especially so
considering that graw is (as far as I understand) intended to be a nice
abstraction that hides gotchas like this. So this commit tells graw to
pass raw_json=1 in every GET request.

For graw bots that expect <, >, and & delivered as HTML entites, this is
a breaking change.