### PR TITLE
Fixing a memory leak problem in the HTTP client

### DIFF
--- a/reddit/client.go
+++ b/reddit/client.go
@@ -34,6 +34,7 @@ func (b *baseClient) Do(req *http.Request) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	switch resp.StatusCode {
 	case http.StatusOK:


### PR DESCRIPTION
I think this is causing my bot to keep crashing over and over every three hours because it keeps running out of memory.