### PR TITLE
Support application-only oauth

### DIFF
--- a/reddit/app.go
+++ b/reddit/app.go
@@ -1,5 +1,13 @@
 package reddit
 
+import "fmt"
+
+var (
+	errMissingOauthCredentials = fmt.Errorf("missing oauth credentials")
+	errMissingUsername         = fmt.Errorf("missing username")
+	errMissingPassword         = fmt.Errorf("missing password")
+)
+
 // App holds all the information needed to identify as a registered app on
 // Reddit. If you are unfamiliar with this information, you can find it in your
 // "apps" tab on reddit; see this tutorial:
@@ -18,15 +26,22 @@ type App struct {
 	tokenURL string
 }
 
-func (a App) configured() bool {
-	allNotEmpty := func(ss ...string) bool {
-		for _, s := range ss {
-			if s == "" {
-				return false
-			}
-		}
-		return true
+func (a App) unauthenticated() bool {
+	return a.ID == "" || a.Secret == ""
+}
+
+func (a App) validateAuth() error {
+	if a.unauthenticated() {
+		return errMissingOauthCredentials
 	}
 
-	return allNotEmpty(a.tokenURL, a.ID, a.Secret)
+	if a.Password != "" && a.Username == "" {
+		return errMissingUsername
+	}
+
+	if a.Username != "" && a.Password == "" {
+		return errMissingPassword
+	}
+
+	return nil
 }

--- a/reddit/app.go
+++ b/reddit/app.go
@@ -28,5 +28,5 @@ func (a App) configured() bool {
 		return true
 	}
 
-	return allNotEmpty(a.tokenURL, a.ID, a.Secret, a.Username, a.Password)
+	return allNotEmpty(a.tokenURL, a.ID, a.Secret)
 }

--- a/reddit/app_test.go
+++ b/reddit/app_test.go
@@ -11,6 +11,7 @@ func TestAppConfigured(t *testing.T) {
 	}{
 		{App{"", "", "", "", ""}, false},
 		{App{"y", "y", "y", "y", "y"}, true},
+		{App{"y", "y", "", "", "y"}, false},
 		{App{"", "", "y", "y", "y"}, false},
 		{App{"", "", "y", "", ""}, false},
 		{App{"", "y", "", "y", ""}, false},

--- a/reddit/app_test.go
+++ b/reddit/app_test.go
@@ -4,19 +4,38 @@ import (
 	"testing"
 )
 
-func TestAppConfigured(t *testing.T) {
+func TestAppUnauthenticated(t *testing.T) {
 	for i, test := range []struct {
 		input  App
 		output bool
 	}{
-		{App{"", "", "", "", ""}, false},
-		{App{"y", "y", "y", "y", "y"}, true},
-		{App{"y", "y", "", "", "y"}, false},
-		{App{"", "", "y", "y", "y"}, false},
-		{App{"", "", "y", "", ""}, false},
-		{App{"", "y", "", "y", ""}, false},
+		{App{"y", "", "", "", ""}, true},
+		{App{"", "y", "", "", ""}, true},
+		{App{"y", "y", "", "", ""}, false},
+		{App{"y", "y", "y", "", ""}, false},
+		{App{"y", "y", "", "y", ""}, false},
+		{App{"y", "y", "y", "y", ""}, false},
 	} {
-		if actual := test.input.configured(); actual != test.output {
+		if actual := test.input.unauthenticated(); actual != test.output {
+			t.Errorf("wrong on %d; wanted %v", i, test.output)
+		}
+	}
+}
+
+func TestAppValidateAuth(t *testing.T) {
+	for i, test := range []struct {
+		input  App
+		output error
+	}{
+		{App{"", "", "", "", ""}, errMissingOauthCredentials},
+		{App{"y", "", "", "", ""}, errMissingOauthCredentials},
+		{App{"", "y", "", "", ""}, errMissingOauthCredentials},
+		{App{"y", "y", "y", "", ""}, errMissingPassword},
+		{App{"y", "y", "", "y", ""}, errMissingUsername},
+		{App{"y", "y", "", "", ""}, nil},
+		{App{"y", "y", "y", "y", ""}, nil},
+	} {
+		if actual := test.input.validateAuth(); actual != test.output {
 			t.Errorf("wrong on %d; wanted %v", i, test.output)
 		}
 	}

--- a/reddit/client.go
+++ b/reddit/client.go
@@ -68,9 +68,13 @@ func newClient(c clientConfig) (client, error) {
 		c.app.tokenURL = tokenURL
 	}
 
-	if c.app.configured() {
-		return newAppClient(c)
+	if c.app.unauthenticated() {
+		return &baseClient{clientWithAgent(c.agent)}, nil
 	}
 
-	return &baseClient{clientWithAgent(c.agent)}, nil
+	if err := c.app.validateAuth(); err != nil {
+		return nil, err
+	}
+
+	return newAppClient(c)
 }


### PR DESCRIPTION
Addresses https://github.com/turnage/graw/issues/45.

Note that I removed the re-authorization from the `appClient.Do` because the token should be refreshed automatically as per the [oauth2 documentation](https://godoc.org/golang.org/x/oauth2#Config.Client). The same should apply to the [clientcredentials.Client](https://godoc.org/golang.org/x/oauth2/clientcredentials#Config.Client).