### PR TITLE
Adding support for passing in an existing oauth2.Token in the App config

### DIFF
--- a/reddit/app.go
+++ b/reddit/app.go
@@ -1,6 +1,10 @@
 package reddit
 
-import "fmt"
+import (
+	"fmt"
+
+	"golang.org/x/oauth2"
+)
 
 var (
 	errMissingOauthCredentials = fmt.Errorf("missing oauth credentials")
@@ -24,15 +28,22 @@ type App struct {
 
 	// tokenURL is the url of the token request location for OAuth2.
 	tokenURL string
+
+	// If token is specified, username/password authentication is skipped
+	Token *oauth2.Token
 }
 
 func (a App) unauthenticated() bool {
-	return a.ID == "" || a.Secret == ""
+	return a.Token == nil && (a.ID == "" || a.Secret == "")
 }
 
 func (a App) validateAuth() error {
 	if a.unauthenticated() {
 		return errMissingOauthCredentials
+	}
+
+	if a.Token != nil {
+		return nil
 	}
 
 	if a.Password != "" && a.Username == "" {

--- a/reddit/app_test.go
+++ b/reddit/app_test.go
@@ -2,6 +2,8 @@ package reddit
 
 import (
 	"testing"
+
+	"golang.org/x/oauth2"
 )
 
 func TestAppUnauthenticated(t *testing.T) {
@@ -9,12 +11,14 @@ func TestAppUnauthenticated(t *testing.T) {
 		input  App
 		output bool
 	}{
-		{App{"y", "", "", "", ""}, true},
-		{App{"", "y", "", "", ""}, true},
-		{App{"y", "y", "", "", ""}, false},
-		{App{"y", "y", "y", "", ""}, false},
-		{App{"y", "y", "", "y", ""}, false},
-		{App{"y", "y", "y", "y", ""}, false},
+		{App{"y", "", "", "", "", nil}, true},
+		{App{"", "y", "", "", "", nil}, true},
+		{App{"y", "", "", "", "", &oauth2.Token{}}, false},
+		{App{"", "y", "", "", "", &oauth2.Token{}}, false},
+		{App{"y", "y", "", "", "", nil}, false},
+		{App{"y", "y", "y", "", "", nil}, false},
+		{App{"y", "y", "", "y", "", nil}, false},
+		{App{"y", "y", "y", "y", "", nil}, false},
 	} {
 		if actual := test.input.unauthenticated(); actual != test.output {
 			t.Errorf("wrong on %d; wanted %v", i, test.output)
@@ -27,13 +31,18 @@ func TestAppValidateAuth(t *testing.T) {
 		input  App
 		output error
 	}{
-		{App{"", "", "", "", ""}, errMissingOauthCredentials},
-		{App{"y", "", "", "", ""}, errMissingOauthCredentials},
-		{App{"", "y", "", "", ""}, errMissingOauthCredentials},
-		{App{"y", "y", "y", "", ""}, errMissingPassword},
-		{App{"y", "y", "", "y", ""}, errMissingUsername},
-		{App{"y", "y", "", "", ""}, nil},
-		{App{"y", "y", "y", "y", ""}, nil},
+		{App{"", "", "", "", "", nil}, errMissingOauthCredentials},
+		{App{"y", "", "", "", "", nil}, errMissingOauthCredentials},
+		{App{"", "y", "", "", "", nil}, errMissingOauthCredentials},
+		{App{"y", "y", "y", "", "", nil}, errMissingPassword},
+		{App{"y", "y", "", "y", "", nil}, errMissingUsername},
+		{App{"", "", "", "", "", &oauth2.Token{}}, nil},
+		{App{"y", "", "", "", "", &oauth2.Token{}}, nil},
+		{App{"", "y", "", "", "", &oauth2.Token{}}, nil},
+		{App{"y", "y", "y", "", "", &oauth2.Token{}}, nil},
+		{App{"y", "y", "", "y", "", &oauth2.Token{}}, nil},
+		{App{"y", "y", "", "", "", nil}, nil},
+		{App{"y", "y", "y", "y", "", nil}, nil},
 	} {
 		if actual := test.input.validateAuth(); actual != test.output {
 			t.Errorf("wrong on %d; wanted %v", i, test.output)


### PR DESCRIPTION
Support for using an existing OAuth2 token instead of authenticating via username/password.

Addresses https://github.com/turnage/graw/issues/48