### PR TITLE
Adding error handling on PasswordCredentialsToken

### DIFF
--- a/reddit/appclient.go
+++ b/reddit/appclient.go
@@ -54,6 +54,9 @@ func (a *appClient) authorize() error {
 		a.cfg.app.Username,
 		a.cfg.app.Password,
 	)
+	if err != nil {
+		return err
+	}
 
 	a.baseClient.cli = cfg.Client(ctx, token)
 	a.expiry = token.Expiry


### PR DESCRIPTION
Hello, I was playing with this library and realized that if you input wrong credentials (password in my case) you get a panic when you try to create a new bot using `reddit.NewBotFromAgentFile`

This happens because there is an error being ignored when generating the token, this PR fixes it.

**Following the execution result before:**
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x72b72a]

goroutine 1 [running]:
github.com/turnage/graw/reddit.(*appClient).authorize(0xc0000f8000, 0xc0000f8000, 0xc0000e8097)
        /home/myhome/go/pkg/mod/github.com/turnage/graw@v0.0.0-20191224200831-a592320d5bc9/reddit/appclient.go:59 +0x24a
github.com/turnage/graw/reddit.newAppClient(0xc0000ea00d, 0x1e, 0xc0000ea039, 0xe, 0xc0000ea059, 0x1b, 0xc0000ea081, 0x7, 0xc0000ea095, 0x1, ...)
        /home/myhome/go/pkg/mod/github.com/turnage/graw@v0.0.0-20191224200831-a592320d5bc9/reddit/appclient.go:79 +0xff
github.com/turnage/graw/reddit.newClient(0xc0000ea00d, 0x1e, 0xc0000ea039, 0xe, 0xc0000ea059, 0x1b, 0xc0000ea081, 0x7, 0xc0000ea095, 0x1, ...)
        /home/myhome/go/pkg/mod/github.com/turnage/graw@v0.0.0-20191224200831-a592320d5bc9/reddit/client.go:79 +0x15a
github.com/turnage/graw/reddit.NewBot(0xc0000ea00d, 0x1e, 0xc0000ea039, 0xe, 0xc0000ea059, 0x1b, 0xc0000ea081, 0x7, 0xc0000ea095, 0x1, ...)
        /home/myhome/go/pkg/mod/github.com/turnage/graw@v0.0.0-20191224200831-a592320d5bc9/reddit/bot.go:38 +0xba
github.com/turnage/graw/reddit.NewBotFromAgentFile(0x7f58a9, 0x9, 0x0, 0xc000054f20, 0x43cd1a, 0xa9ef80, 0xc000000180)
```


**and after**
```
2020/02/16 06:56:31 failed to initialize botoauth2: cannot fetch token: 401 Unauthorized
Response: {"message": "Unauthorized", "error": 401}
```