### PR TITLE
Get post response

### DIFF
--- a/reddit/account.go
+++ b/reddit/account.go
@@ -12,15 +12,18 @@ type Account interface {
 	// Use .Name on the parent post, message, or comment to find its
 	// name.
 	Reply(parentName, text string) error
+	GetReply(parentName, text string) (Submission, error)
 
 	// SendMessage sends a private message to a user.
 	SendMessage(user, subject, text string) error
 
 	// PostSelf makes a text (self) post to a subreddit.
 	PostSelf(subreddit, title, text string) error
+	GetPostSelf(subreddit, title, text string) (Submission, error)
 
 	// PostLink makes a link post to a subreddit.
 	PostLink(subreddit, title, url string) error
+	GetPostLink(subreddit, title, url string) (Submission, error)
 }
 
 type account struct {
@@ -38,6 +41,15 @@ func newAccount(r reaper) Account {
 
 func (a *account) Reply(parentName, text string) error {
 	return a.r.sow(
+		"/api/comment", map[string]string{
+			"thing_id": parentName,
+			"text":     text,
+		},
+	)
+}
+
+func (a *account) GetReply(parentName, text string) (Submission, error) {
+	return a.r.get_sow(
 		"/api/comment", map[string]string{
 			"thing_id": parentName,
 			"text":     text,
@@ -66,8 +78,30 @@ func (a *account) PostSelf(subreddit, title, text string) error {
 	)
 }
 
+func (a *account) GetPostSelf(subreddit, title, text string) (Submission, error) {
+	return a.r.get_sow(
+		"/api/submit", map[string]string{
+			"sr":    subreddit,
+			"kind":  "self",
+			"title": title,
+			"text":  text,
+		},
+	)
+}
+
 func (a *account) PostLink(subreddit, title, url string) error {
 	return a.r.sow(
+		"/api/submit", map[string]string{
+			"sr":    subreddit,
+			"kind":  "link",
+			"title": title,
+			"url":   url,
+		},
+	)
+}
+
+func (a *account) GetPostLink(subreddit, title, url string) (Submission, error) {
+	return a.r.get_sow(
 		"/api/submit", map[string]string{
 			"sr":    subreddit,
 			"kind":  "link",

--- a/reddit/data.go
+++ b/reddit/data.go
@@ -160,3 +160,9 @@ type Harvest struct {
 	Posts    []*Post
 	Messages []*Message
 }
+
+type Submission struct {
+	ID   string `mapstructure:"id"`
+	Name string `mapstructure:"name"`
+	URL  string `mapstructure:"url"`
+}

--- a/reddit/mockparser_test.go
+++ b/reddit/mockparser_test.go
@@ -5,9 +5,10 @@ import (
 )
 
 type mockParser struct {
-	comments []*Comment
-	posts    []*Post
-	messages []*Message
+	comments   []*Comment
+	posts      []*Post
+	messages   []*Message
+	submission Submission
 }
 
 func (m *mockParser) parse(

--- a/reddit/mockparser_test.go
+++ b/reddit/mockparser_test.go
@@ -17,6 +17,12 @@ func (m *mockParser) parse(
 	return m.comments, m.posts, m.messages, nil
 }
 
+func (m *mockParser) parse_submitted(
+	blob json.RawMessage,
+) (Submission, error) {
+	return m.submission, nil
+}
+
 func parserWhich(h Harvest) parser {
 	return &mockParser{
 		comments: h.Comments,

--- a/reddit/mockreaper_test.go
+++ b/reddit/mockreaper_test.go
@@ -6,6 +6,7 @@ type mockReaper struct {
 	path string
 
 	h   Harvest
+	s   Submission
 	err error
 }
 

--- a/reddit/mockreaper_test.go
+++ b/reddit/mockreaper_test.go
@@ -20,6 +20,11 @@ func (m *mockReaper) sow(path string, _ map[string]string) error {
 	return m.err
 }
 
+func (m *mockReaper) get_sow(path string, _ map[string]string) (Submission, error) {
+	m.path = path
+	return m.s, m.err
+}
+
 func reaperWhich(h Harvest, err error) *mockReaper {
 	return &mockReaper{
 		h:   h,

--- a/reddit/reddit_test.go
+++ b/reddit/reddit_test.go
@@ -39,6 +39,24 @@ func TestAccount(t *testing.T) {
 				},
 			},
 			testCase{
+				name: "GetReply",
+				f: func(b Bot) error {
+					_, err := b.GetReply("name", "text")
+					return err
+				},
+				correct: http.Request{
+					Method: "POST",
+					URL: &url.URL{
+						Scheme:   "https",
+						Host:     "reddit.com",
+						Path:     "/api/comment",
+						RawQuery: "api_type=json&text=text&thing_id=name",
+					},
+					Host:   "reddit.com",
+					Header: formEncoding,
+				},
+			},
+			testCase{
 				name: "SendMessage",
 				f: func(b Bot) error {
 					return b.SendMessage("user", "subject", "text")
@@ -73,6 +91,25 @@ func TestAccount(t *testing.T) {
 				},
 			},
 			testCase{
+				name: "GetPostSelf",
+				f: func(b Bot) error {
+					_, err := b.GetPostSelf("self", "title", "text")
+					return err
+
+				},
+				correct: http.Request{
+					Method: "POST",
+					URL: &url.URL{
+						Scheme:   "https",
+						Host:     "reddit.com",
+						Path:     "/api/submit",
+						RawQuery: "api_type=json&kind=self&sr=self&text=text&title=title",
+					},
+					Host:   "reddit.com",
+					Header: formEncoding,
+				},
+			},
+			testCase{
 				name: "PostLink",
 				f: func(b Bot) error {
 					return b.PostLink("link", "title", "url")
@@ -84,6 +121,24 @@ func TestAccount(t *testing.T) {
 						Host:     "reddit.com",
 						Path:     "/api/submit",
 						RawQuery: "kind=link&sr=link&title=title&url=url",
+					},
+					Host:   "reddit.com",
+					Header: formEncoding,
+				},
+			},
+			testCase{
+				name: "GetPostLink",
+				f: func(b Bot) error {
+					_, err := b.GetPostLink("link", "title", "url")
+					return err
+				},
+				correct: http.Request{
+					Method: "POST",
+					URL: &url.URL{
+						Scheme:   "https",
+						Host:     "reddit.com",
+						Path:     "/api/submit",
+						RawQuery: "api_type=json&kind=link&sr=link&title=title&url=url",
 					},
 					Host:   "reddit.com",
 					Header: formEncoding,


### PR DESCRIPTION
The purpose of this branch is to add functionality of getting references to posts or comments POSTed to Reddit when they are created. For example this is useful for bots that post content that requires a description comment or a flare to be added at post time. Because Reddit does not return full post objects when submitted, the Submission type is only meant to contain a name, id, and url to access those created resources normally.

This is done by adding account methods `GetReply`, `GetPostSelf`, and `GetPostLink` that use a new sow method `get_sow`, which itself uses a new parser method `parse_submitted`. The existing parsing method was not used because of differences in how Reddit formats json requests made with suffix `.json` and the url_param `api_type=json` that these new methods use.

Tests have been written for added methods, and mock types implement mock instances of these methods where they should. 