### PR TITLE
Add function to load a bot from variables

### DIFF
--- a/reddit/bot.go
+++ b/reddit/bot.go
@@ -72,3 +72,23 @@ func NewBotFromAgentFile(filename string, rate time.Duration) (Bot, error) {
 		},
 	)
 }
+
+// NewBotFromVars call NewBot using the variables given to create a new bot
+// Designed as a Drop-in replacement for NewBotFromAgentFIle, allowing the users
+// to load the variables any way they choose.
+func NewBotFromVars(userAgent string, clientID string, clientSecret string, username string, password string, rate time.Duration) (Bot, error) {
+	app := App{
+		ID:       clientID,
+		Secret:   clientSecret,
+		Username: username,
+		Password: password,
+	}
+
+	return NewBot(
+		BotConfig{
+			Agent: userAgent,
+			App:   app,
+			Rate:  rate,
+		},
+	)
+}


### PR DESCRIPTION
This change adds a small function to the file located in `reddit/bot.go` that simply allows users to load a bot via any variables they wish, allow for them to load it via any other file type they wish. For my personal use case, since I am running my application in a Docker container, I pass all API keys in via environment variables. This allows me to have the client ID and secret saved on my host and passed in as environment variables. I did not write a test as I do not believe this function warrants one, as the similar function do not have them either. I understand that you could just write the config yourself, but this method allows for a drop in replacement if needed.