### PR TITLE
pass correct client to patchWithAgent in newAppClient

### DIFF
--- a/reddit/appclient.go
+++ b/reddit/appclient.go
@@ -79,7 +79,7 @@ func newAppClient(c clientConfig) (*appClient, error) {
 	if c.client == nil {
 		client = clientWithAgent(c.agent)
 	} else {
-		client = patchWithAgent(client, c.agent)
+		client = patchWithAgent(c.client, c.agent)
 	}
 
 	a := &appClient{


### PR DESCRIPTION
i ran into the following panic in master when passing a custom http client in `BotConfig`. looks like it was a minor oversight in the call to `patchWithAgent` in `newAppClient`. 

panic:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe124f6]

goroutine 1 [running]:
panic(0x14579c0, 0x24f43b0)
	/usr/local/go/src/runtime/panic.go:969 +0x166
github.com/turnage/graw/reddit.patchWithAgent(...)
	/app/vendor/github.com/turnage/graw/reddit/agentforwarder.go:21
github.com/turnage/graw/reddit.newAppClient(0x1665af7, 0xe, 0xc0000400ee, 0xe, 0xc000042102, 0x1b, 0x0, 0x0, 0x0, 0x0, ...)
	/app/vendor/github.com/turnage/graw/reddit/appclient.go:82 +0x46
github.com/turnage/graw/reddit.newClient(0x1665af7, 0xe, 0xc0000400ee, 0xe, 0xc000042102, 0x1b, 0x0, 0x0, 0x0, 0x0, ...)
	/app/vendor/github.com/turnage/graw/reddit/client.go:82 +0x2fb
github.com/turnage/graw/reddit.NewBot(0x1665af7, 0xe, 0xc0000400ee, 0xe, 0xc000042102, 0x1b, 0x0, 0x0, 0x0, 0x0, ...)
	/app/vendor/github.com/turnage/graw/reddit/bot.go:41 +0xe4
```

example code to reproduce:
```
	client := &http.Client{
		Transport: &http.Transport{
			IdleConnTimeout:     defaultIdleConnTimeout,
			MaxIdleConnsPerHost: maxConnections,
		},
		Timeout: timeout,
	}

	bot, err := reddit.NewBot(reddit.BotConfig{
		Agent:  agent,
		Rate:   time.Second * 1,
		Client: client,
		App: reddit.App{
			ID:     config.Reddit.API.ID,
			Secret: config.Reddit.API.Secret,
		},
	})
```