### PR TITLE
Add support for comment's edited field

### DIFF
--- a/reddit/data.go
+++ b/reddit/data.go
@@ -10,6 +10,7 @@ type Comment struct {
 	Permalink string `mapstructure:"permalink"`
 
 	CreatedUTC uint64 `mapstructure:"created_utc"`
+	Edited     uint64 `mapstructure:"edited"`
 	Deleted    bool   `mapstructure:"deleted"`
 
 	Ups   int32 `mapstructure:"ups"`

--- a/reddit/parse.go
+++ b/reddit/parse.go
@@ -261,6 +261,14 @@ func parseComment(t *thing) (*Comment, error) {
 			delete(t.Data, "replies")
 		}
 	}
+	// Similarly, edited is false if a post hasn't been edited and a timestamp
+	// otherwise.
+	value, present = t.Data["edited"]
+	if present {
+		if _, ok := value.(bool); ok {
+			delete(t.Data, "edited")
+		}
+	}
 
 	c := &comment{}
 	if err := mapstructure.Decode(t.Data, c); err != nil {

--- a/reddit/parse_test.go
+++ b/reddit/parse_test.go
@@ -62,6 +62,21 @@ func TestParseThread(t *testing.T) {
 		)
 	}
 
+	if post.Replies[0].Edited != 0 {
+		t.Errorf(
+			"first comment's edit state is incorrect: %d",
+			post.Replies[0].Edited,
+		)
+	}
+
+	if post.Replies[1].Replies[0].Replies[1].Edited != 1366216653 {
+		t.Errorf(
+			"comment %s edit timestamp is incorrect: %d",
+			post.Replies[1].Replies[0].Replies[1].ID,
+			post.Replies[1].Replies[0].Replies[1].Edited,
+		)
+	}
+
 	if len(post.Replies[0].Replies) < 1 {
 		t.Fatalf("bacon_cake should have replies but doesn't")
 	}


### PR DESCRIPTION
`edited` on comments is the timestamp of the last edit, or `false` if there hasn't been an edit. We don't need different types for this, a  timestamp of 0 is sufficient to convey "no edit".