### PR TITLE
adding upload ratio in post

### DIFF
--- a/reddit/data.go
+++ b/reddit/data.go
@@ -13,9 +13,10 @@ type Comment struct {
 	Edited     uint64 `mapstructure:"edited"`
 	Deleted    bool   `mapstructure:"deleted"`
 
-	Ups   int32 `mapstructure:"ups"`
-	Downs int32 `mapstructure:"downs"`
-	Likes bool  `mapstructure:"likes"`
+	Ups         int32   `mapstructure:"ups"`
+	Downs       int32   `mapstructure:"downs"`
+	Likes       bool    `mapstructure:"likes"`
+	UpvoteRatio float32 `mapstructure:"upvote_ratio"`
 
 	Author              string `mapstructure:"author"`
 	AuthorFlairCSSClass string `mapstructure:"author_flair_css_class"`


### PR DESCRIPTION
Reddit doesn't show down vote counts therefore the ratio is needed to compute the value from the upvote count.