### PR TITLE
make Reaper accessible in Bot

### DIFF
--- a/reddit/account.go
+++ b/reddit/account.go
@@ -28,19 +28,19 @@ type Account interface {
 
 type account struct {
 	// r is used to execute requests to Reddit.
-	r reaper
+	r Reaper
 }
 
 // newAccount returns a new Account using the given reaper to make requests
 // to Reddit.
-func newAccount(r reaper) Account {
+func newAccount(r Reaper) Account {
 	return &account{
 		r: r,
 	}
 }
 
 func (a *account) Reply(parentName, text string) error {
-	return a.r.sow(
+	return a.r.Sow(
 		"/api/comment", map[string]string{
 			"thing_id": parentName,
 			"text":     text,
@@ -49,7 +49,7 @@ func (a *account) Reply(parentName, text string) error {
 }
 
 func (a *account) GetReply(parentName, text string) (Submission, error) {
-	return a.r.get_sow(
+	return a.r.GetSow(
 		"/api/comment", map[string]string{
 			"thing_id": parentName,
 			"text":     text,
@@ -58,7 +58,7 @@ func (a *account) GetReply(parentName, text string) (Submission, error) {
 }
 
 func (a *account) SendMessage(user, subject, text string) error {
-	return a.r.sow(
+	return a.r.Sow(
 		"/api/compose", map[string]string{
 			"to":      user,
 			"subject": subject,
@@ -68,7 +68,7 @@ func (a *account) SendMessage(user, subject, text string) error {
 }
 
 func (a *account) PostSelf(subreddit, title, text string) error {
-	return a.r.sow(
+	return a.r.Sow(
 		"/api/submit", map[string]string{
 			"sr":    subreddit,
 			"kind":  "self",
@@ -79,7 +79,7 @@ func (a *account) PostSelf(subreddit, title, text string) error {
 }
 
 func (a *account) GetPostSelf(subreddit, title, text string) (Submission, error) {
-	return a.r.get_sow(
+	return a.r.GetSow(
 		"/api/submit", map[string]string{
 			"sr":    subreddit,
 			"kind":  "self",
@@ -90,7 +90,7 @@ func (a *account) GetPostSelf(subreddit, title, text string) (Submission, error)
 }
 
 func (a *account) PostLink(subreddit, title, url string) error {
-	return a.r.sow(
+	return a.r.Sow(
 		"/api/submit", map[string]string{
 			"sr":    subreddit,
 			"kind":  "link",
@@ -101,7 +101,7 @@ func (a *account) PostLink(subreddit, title, url string) error {
 }
 
 func (a *account) GetPostLink(subreddit, title, url string) (Submission, error) {
-	return a.r.get_sow(
+	return a.r.GetSow(
 		"/api/submit", map[string]string{
 			"sr":    subreddit,
 			"kind":  "link",

--- a/reddit/bot.go
+++ b/reddit/bot.go
@@ -28,12 +28,14 @@ type Bot interface {
 	Account
 	Lurker
 	Scanner
+	Reaper
 }
 
 type bot struct {
 	Account
 	Lurker
 	Scanner
+	Reaper
 }
 
 // NewBot returns a logged in handle to the Reddit API.
@@ -52,6 +54,7 @@ func NewBot(c BotConfig) (Bot, error) {
 		Account: newAccount(r),
 		Lurker:  newLurker(r),
 		Scanner: newScanner(r),
+		Reaper: r,
 	}, err
 }
 

--- a/reddit/lurker.go
+++ b/reddit/lurker.go
@@ -7,15 +7,15 @@ type Lurker interface {
 }
 
 type lurker struct {
-	r reaper
+	r Reaper
 }
 
-func newLurker(r reaper) Lurker {
+func newLurker(r Reaper) Lurker {
 	return &lurker{r: r}
 }
 
 func (s *lurker) Thread(permalink string) (*Post, error) {
-	harvest, err := s.r.reap(
+	harvest, err := s.r.Reap(
 		permalink+".json",
 		map[string]string{"raw_json": "1"},
 	)

--- a/reddit/mockreaper_test.go
+++ b/reddit/mockreaper_test.go
@@ -10,20 +10,22 @@ type mockReaper struct {
 	err error
 }
 
-func (m *mockReaper) reap(path string, _ map[string]string) (Harvest, error) {
+func (m *mockReaper) Reap(path string, _ map[string]string) (Harvest, error) {
 	m.path = path
 	return m.h, m.err
 }
 
-func (m *mockReaper) sow(path string, _ map[string]string) error {
+func (m *mockReaper) Sow(path string, _ map[string]string) error {
 	m.path = path
 	return m.err
 }
 
-func (m *mockReaper) get_sow(path string, _ map[string]string) (Submission, error) {
+func (m *mockReaper) GetSow(path string, _ map[string]string) (Submission, error) {
 	m.path = path
 	return m.s, m.err
 }
+
+func (m *mockReaper) RateBlock() {}
 
 func reaperWhich(h Harvest, err error) *mockReaper {
 	return &mockReaper{

--- a/reddit/reaper_test.go
+++ b/reddit/reaper_test.go
@@ -95,7 +95,7 @@ func TestReap(t *testing.T) {
 			mu:       &sync.Mutex{},
 		}
 
-		Harvest, err := r.reap(test.path, test.values)
+		Harvest, err := r.Reap(test.path, test.values)
 		if err != nil {
 			t.Errorf("Error reaping input %d: %v", i, err)
 		}
@@ -159,7 +159,7 @@ func TestSow(t *testing.T) {
 			mu:       &sync.Mutex{},
 		}
 
-		if err := r.sow(test.path, test.values); err != nil {
+		if err := r.Sow(test.path, test.values); err != nil {
 			t.Errorf("Error reaping input %d: %v", i, err)
 		}
 
@@ -170,14 +170,14 @@ func TestSow(t *testing.T) {
 }
 
 func TestRateBlockReap(t *testing.T) {
-	testRateBlock(func(r reaper) { r.reap("", nil) }, t)
+	testRateBlock(func(r Reaper) { r.Reap("", nil) }, t)
 }
 
 func TestRateBlockSow(t *testing.T) {
-	testRateBlock(func(r reaper) { r.sow("", nil) }, t)
+	testRateBlock(func(r Reaper) { r.Sow("", nil) }, t)
 }
 
-func testRateBlock(f func(reaper), t *testing.T) {
+func testRateBlock(f func(Reaper), t *testing.T) {
 	start := time.Now()
 	r := &reaperImpl{
 		cli:    &mockClient{},

--- a/reddit/reddit_test.go
+++ b/reddit/reddit_test.go
@@ -211,6 +211,7 @@ func testRequests(cases []testCase, t *testing.T) {
 		Account: newAccount(r),
 		Lurker:  newLurker(r),
 		Scanner: newScanner(r),
+		Reaper:  r,
 	}
 	for _, test := range cases {
 		if err := test.f(b); err != test.err {

--- a/reddit/scanner.go
+++ b/reddit/scanner.go
@@ -31,15 +31,15 @@ type Scanner interface {
 }
 
 type scanner struct {
-	r reaper
+	r Reaper
 }
 
-func newScanner(r reaper) Scanner {
+func newScanner(r Reaper) Scanner {
 	return &scanner{r: r}
 }
 
 func (s *scanner) Listing(path, after string) (Harvest, error) {
-	return s.r.reap(
+	return s.r.Reap(
 		path, map[string]string{
 			"raw_json": "1",
 			"limit":    "100",
@@ -59,5 +59,5 @@ func (s *scanner) ListingWithParams(path string, params map[string]string) (
 	for key, value := range params {
 		reaperParams[key] = value
 	}
-	return s.r.reap(path, reaperParams)
+	return s.r.Reap(path, reaperParams)
 }


### PR DESCRIPTION
This commit is a refactoring of the types bot, Bot, account, lurker, scanner and reaper (with mockReaper). The goal is to make reaper available outside the package (as #59 requests).
Detailed modifications:
- Renaming "reaper" to "Reaper" to export the interface,
- Exporting methods reap -> Reap,
sow -> Sow, get_sow -> GetSow, rateBlock -> RateBlock,
- Adding RateBlock to the new Reaper interface.
To avoid breaking compatibility only private interface/type were modified, one interface was exported with a new method.
No new tests were added : the exported methods are already tested and no new functionalities were added.